### PR TITLE
use ph_with instead of ph_with_* functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: export
 Type: Package
 Title: Streamlined Export of Graphs and Data Tables
-Version: 0.2.2.9000
+Version: 0.2.2.9001
 Date: 2018-09-18
 Authors@R: c(person("Tom", "Wenseleers", role = c("aut", "cre"),
     	     email = "tom.wenseleers@kuleuven.be"),

--- a/R/graph2office.R
+++ b/R/graph2office.R
@@ -179,13 +179,13 @@ graph2office = function(x = NULL, file = "Rplot", fun = NULL, type = c("PPT","DO
       offy = (pagesize["height"] + margins["top"]+margins["bottom"] - h)/2
     }
     if(vector.graphic){
-      doc = ph_with_vg_at(doc, code = myplot(), left = offx, top = offy, width = w, height = h, ...)
+      doc = ph_with(doc, dml(code = myplot()), location = ph_location(left = offx, top = offy, width = w, height = h), ...)
     } else {
       temp.file <- paste0(tempfile(), ".png")
       grDevices::png(filename = temp.file, height = h, width = w, units = "in", res = 300)
       myplot()
       dev.off()
-      doc <- ph_with_img_at(doc, src = temp.file, left = offx, top = offy, width = w, height = h)
+      doc <- ph_with(doc, external_img(src = temp.file), location = ph_location(left = offx, top = offy, width = w, height = h))
       unlink(temp.file)
     }
   } else {

--- a/R/table2office.R
+++ b/R/table2office.R
@@ -288,7 +288,7 @@ table2office = function(x = NULL, file = "Rtable", type = c("PPT","DOC"), append
   
   
   if(type=="PPT"){
-    doc <- ph_with_flextable_at(doc, value = tab , left=offx, top=offy)
+    doc <- ph_with(doc, value = tab , location = ph_location(left = offx, top = offy))
   } else if(type == "DOC"){
     doc <- body_add_flextable(doc, value = tab)
   } 


### PR DESCRIPTION
Dear Tom,

This PR should help in adjusting your code to the usage of `officer::ph_with` and
`rvg::dml` instead of functions `officer::ph_with_*` that should be deprecated soon.

Let me know if you have questions about ph_with.

KR,
David
